### PR TITLE
Update Train_Manager.py

### DIFF
--- a/mytflib/Train_Manager.py
+++ b/mytflib/Train_Manager.py
@@ -67,11 +67,11 @@ def change_np_float_to_float(Dict):
       if type(value) is dict:
         change_np_float_to_float(Dict[key]) ##Recursive in case of nested dictionary
 
-      elif type(value) is type(tf.lookup.StaticHashTable(tf.lookup.KeyValueTensorInitializer(
-    tf.constant([1,1]), tf.constant([1,1])),default_value = 0)):
+      #elif type(value) is type(tf.lookup.StaticHashTable(tf.lookup.KeyValueTensorInitializer(
+    #tf.constant([1,1]), tf.constant([1,1])),default_value = 0)):
 
     
-        Dict[key] = float(value.size().numpy())
+        #Dict[key] = float(value.size().numpy())
 
       elif type(value) is list:
         Dict[key] =[float(ele) for ele in value]


### PR DESCRIPTION
"tensorflow.python.framework.errors_impl.FailedPreconditionError: Table was already initialized with different data."


```
tensorflow.python.framework.errors_impl.FailedPreconditionError: Table was already initialized with different data.
	Encountered when executing an operation using EagerExecutor. This error cancels all future operations and poisons their output tensors. [Op:HashTableV2] name: hash_table
Exception ignored in atexit callback: <function async_wait at 0x7d761c1a4dc0>
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/tensorflow/python/eager/context.py", line 2690, in async_wait
    context().sync_executors()
  File "/usr/local/lib/python3.10/dist-packages/tensorflow/python/eager/context.py", line 712, in sync_executors
    pywrap_tfe.TFE_ContextSyncExecutors(self._context_handle)
tensorflow.python.framework.errors_impl.FailedPreconditionError: Table was already initialized with different data.
	Encountered when executing an operation using EagerExecutor. This error cancels all future operations and poisons their output tensors.
2023-09-14 07:12:50.813258: W tensorflow/core/distributed_runtime/eager/remote_tensor_handle_data.cc:77] Unable to destroy remote tensor handles. If you are running a tf.function, it usually indicates some op in the graph gets an error: Table was already initialized with different data.
	Encountered when executing an operation using EagerExecutor. This error cancels all future operations and poisons their output tensors.
2023-09-14 07:12:51.111362: W ./tensorflow/core/distributed_runtime/eager/destroy_tensor_handle_node.h:58] Ignoring an error encountered when deleting remote tensors handles: INVALID_ARGUMENT: Unable to find the relevant tensor remote_handle: Op ID: 49916, Output num: 0
Additional GRPC error information from remote target /job:worker/replica:0/task:0:
:{"created":"@1694675571.111175366","description":"Error received from peer ipv4:10.89.200.66:8470","file":"external/com_github_grpc_grpc/src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Unable to find the relevant tensor remote_handle: Op ID: 49916, Output num: 0","grpc_status":3} [type.googleapis.com/tensorflow.core.platform.ErrorSourceProto='\x08\x05']
```